### PR TITLE
Adjusted radiation profile to avoid warming above model top

### DIFF
--- a/src/6.1.22/radiate/rad_driv.f90
+++ b/src/6.1.22/radiate/rad_driv.f90
@@ -831,12 +831,13 @@ Subroutine radcalc3 (m1,maxnzp,mcat,iswrtyp,ilwrtyp  &
 use rconstants
 use rrad3
 use micphys
+use mem_grid, only: time
 
 implicit none
 
 integer m1,maxnzp,mcat,ngrid
 integer :: iswrtyp,ilwrtyp
-integer i,j,k
+integer i,j,k,ii,printsound
 integer, save :: ncall = 0,nradmax
 integer, save :: ngass(mg)=(/1, 1, 1/),ngast(mg)=(/1, 1, 1/)
 !     one can choose the gases of importance here,
@@ -887,6 +888,19 @@ nrad = m1 - 1 + narad
    ,prsnz,prsnzp,glat,rtgt,topt,rlongup  &
    ,zm,zt,press,tair,dn0,rv,zml,ztl,pl,tl,dl,rl,o3l,dzl)
 
+printsound = 0
+! print *, "THE TIME IS " , time
+! Routine to print radiation sounding from gridbox 10,10
+! Lucas Sterzinger 2022-11-11
+if(time.eq.0.and.i.eq.10.and.j.eq.10.and.printsound.eq.1) then
+   ! print *, "Running on ", time,
+   OPEN(UNIT=3333, FILE='tl.txt', status ='replace', form='formatted')
+   123 Format(f12.3, ',', f12.3, ',', e14.1,','f12.3,','f12.3)
+   do ii=0,size(tl)
+      write (3333, 123) ztl(ii), tl(ii), rl(ii), pl(ii), dl(ii)
+   enddo
+   stop
+endif
 ! calculate non-dimensional pressure
 do k=1,m1
   exner(k) = (pi0(k)+pp(k))/cp


### PR DESCRIPTION
# Problem
Since we have a low model top, RAMS creates a fake sounding above the model top for radiation calculations. Our model had an unrealistic warm layer above the model

## Temperature full atmosphere
<img width="668" alt="Screen Shot 2022-11-10 at 18 57 17" src="https://user-images.githubusercontent.com/6716906/201417285-0f75530e-be61-4c10-bd2f-2bc1adfaa9dc.png">

## Temperature near domain top
<img width="668" alt="Screen Shot 2022-11-10 at 19 33 17" src="https://user-images.githubusercontent.com/6716906/201417293-bdb1a98b-01f7-4fc7-b512-1dcec3eeb2f2.png">

# Fix
This was fixed (for now) by keeping the temperature and water vapor density constant with height above the model top until intercepted by the fake sounding 

## Temperature full atmosphere
![image](https://user-images.githubusercontent.com/6716906/201417411-175a3291-1cf9-4830-903d-4c2bdd7e7738.png)

## Vapor density full atmosphere
![image](https://user-images.githubusercontent.com/6716906/201417544-e67373ee-aaa5-4a51-a4a9-fdcf68f62832.png)

